### PR TITLE
Add reusable BottomNavBar component with dynamic nav items

### DIFF
--- a/app/src/main/java/com/example/medicalapp/view/components/BottomNavBar.kt
+++ b/app/src/main/java/com/example/medicalapp/view/components/BottomNavBar.kt
@@ -1,0 +1,53 @@
+package com.example.medicalapp.view.components
+
+import androidx.compose.foundation.*
+import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.*
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.*
+import com.example.medicalapp.model.BottomNavItem
+
+@Composable
+fun BottomNavBar(
+    items: List<BottomNavItem>,
+    selectedIndex: Int,
+    onItemSelected: (Int) -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(65.dp)
+            .padding(horizontal = 8.dp),
+        horizontalArrangement = Arrangement.SpaceAround
+    ) {
+        items.forEachIndexed { index, item ->
+            Column(
+                modifier = Modifier
+                    .clickable { onItemSelected(index) }
+                    .padding(vertical = 6.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                val isSelected = index == selectedIndex
+
+                Image(
+                    painter = painterResource(id = item.iconRes),
+                    contentDescription = item.title,
+                    modifier = Modifier
+                        .size(28.dp)
+                        .padding(bottom = 4.dp),
+                    colorFilter = androidx.compose.ui.graphics.ColorFilter.tint(
+                        if (isSelected) Color(0xFF0A8754) else Color.Black
+                    )
+                )
+
+                androidx.compose.material3.Text(
+                    text = item.title,
+                    fontSize = 10.sp,
+                    color = if (isSelected) Color(0xFF0A8754) else Color.Gray
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
Created a reusable BottomNavBar composable to display a bottom navigation bar with five items: Home, Health Plans, Lab Tests, Offers, and Account. The component highlights the active item with a selected color and icon, while keeping others in grayscale.

Nav items are loaded from BottomNavRepository for better scalability and separation of concerns. The selected item index is managed by parent composables for navigation control.