### PR TITLE
Add Top Bar, Bottom Navigation Bar and Preview to HomeScreen

### DIFF
--- a/app/src/main/java/com/example/medicalapp/view/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/medicalapp/view/screen/HomeScreen.kt
@@ -1,0 +1,69 @@
+package com.example.medicalapp.view.screen
+
+import androidx.compose.foundation.*
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.*
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.*
+import com.example.medicalapp.R
+import com.example.medicalapp.repository.*
+import com.example.medicalapp.view.components.*
+
+@Composable
+fun HomeScreen() {
+    val navItems = BottomNavRepository.getBottomNavItems()
+    var selectedTabIndex by remember { mutableStateOf(0) }
+
+    Scaffold(
+        // Nav Bar Items
+        bottomBar = {
+            BottomNavBar(
+                items = navItems,
+                selectedIndex = selectedTabIndex,
+                onItemSelected = { selectedTabIndex = it }
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .padding(paddingValues)
+                .fillMaxSize()
+                .background(Color.White)
+        ) {
+            // Top Bar
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 16.dp, end = 16.dp, bottom = 20.dp),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Menu,
+                    contentDescription = "Menu",
+                    tint = Color(0xFF272140),
+                    modifier = Modifier.size(24.dp)
+                )
+                Image(
+                    painter = painterResource(R.drawable.shopping_basket),
+                    contentDescription = "Cart",
+                    modifier = Modifier.size(24.dp)
+                )
+            }
+
+    }
+}
+
+@Composable
+@Preview(showBackground = true, showSystemUi = true)
+fun HomeScreenPreview() {
+    HomeScreen()
+}


### PR DESCRIPTION
Implemented the initial layout structure for HomeScreen, including :
- Top App Bar with Menu and Cart icons
- Bottom Navigation Bar with 5 items (Home, Health Plans, Lab Tests, Offers, Account)
- Preview composable for HomeScreen preview