### PR TITLE
Add search bar to HomeScreen layout

### DIFF
--- a/app/src/main/java/com/example/medicalapp/view/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/medicalapp/view/screen/HomeScreen.kt
@@ -20,6 +20,7 @@ import com.example.medicalapp.view.components.*
 
 @Composable
 fun HomeScreen() {
+    var searchQuery by remember { mutableStateOf("") }
     val navItems = BottomNavRepository.getBottomNavItems()
     var selectedTabIndex by remember { mutableStateOf(0) }
 
@@ -59,6 +60,24 @@ fun HomeScreen() {
                 )
             }
 
+            // Search Bar
+            OutlinedTextField(
+                value = searchQuery,
+                onValueChange = { searchQuery = it },
+                placeholder = {
+                    Text("Search for Medicines", color = Color.Gray)
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 14.dp),
+                singleLine = true,
+                shape = RoundedCornerShape(16.dp),
+                trailingIcon = {
+                    IconButton(onClick = {}) {
+                        Icon(imageVector = Icons.Default.Search, contentDescription = "Search")
+                    }
+                }
+            )
     }
 }
 


### PR DESCRIPTION
- Implemented an OutlinedTextField as the search bar in HomeScreen.
- Added placeholder text and trailing search icon.
- Bound search input using mutable state (searchQuery).
- Styled the field with padding, rounded corners, and single-line input.