### PR TITLE
Add PagerRepository to provide banner image data

### DIFF
--- a/app/src/main/java/com/example/medicalapp/repository/PagerRepository.kt
+++ b/app/src/main/java/com/example/medicalapp/repository/PagerRepository.kt
@@ -1,0 +1,13 @@
+package com.example.medicalapp.repository
+
+import com.example.medicalapp.R
+
+object PagerRepository {
+    fun getPagerImages() : List<Int> {
+        return listOf(
+            R.drawable.pager_banner_1,
+            R.drawable.pager_banner_2,
+            R.drawable.pager_banner_3
+        )
+    }
+}


### PR DESCRIPTION
- Created PagerRepository to supply a list of drawable resource IDs for banner images.
- This list is used in the ImagePager component to display horizontal image sliders.