### PR TITLE
Add dependencies for Compose pager and pager indicators

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,10 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+
+    implementation("androidx.compose.foundation:foundation:1.6.1")
+    implementation("com.google.accompanist:accompanist-pager-indicators:0.34.0")
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)


### PR DESCRIPTION
- Added androidx.compose.foundation:foundation for built-in HorizontalPager and PagerState.
- Included accompanist-pager-indicators for custom pager indicators