### PR TITLE
Add reusable ImagePager component with custom indicator

### DIFF
--- a/app/src/main/java/com/example/medicalapp/view/components/ImagePager.kt
+++ b/app/src/main/java/com/example/medicalapp/view/components/ImagePager.kt
@@ -1,0 +1,69 @@
+package com.example.medicalapp.view.components
+
+import androidx.compose.foundation.*
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.ExperimentalFoundationApi
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun ImagePager(imageResIds: List<Int>) {
+    val pagerState = rememberPagerState(initialPage = 0, pageCount = { imageResIds.size })
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .wrapContentHeight(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(180.dp)
+        ) { page ->
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clickable{
+                        println("Image $page clicked") // Navigate Later
+                    }
+            ) {
+                Image(
+                    painter = painterResource(id = imageResIds[page]),
+                    contentDescription = "Banner Image $page",
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Row(
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(4.dp)
+        ) {
+            repeat(imageResIds.size) { index ->
+                val isSelected = pagerState.currentPage == index
+                Box(
+                    modifier = Modifier
+                        .padding(horizontal = 4.dp)
+                        .size(if (isSelected) 10.dp else 6.dp)
+                        .background(
+                            color = if (isSelected) Color.Black else Color.Gray,
+                            shape = CircleShape
+                        )
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Created ImagePager composable to display a horizontally scrollable image slider.
- Used HorizontalPager from Jetpack Compose Foundation with custom dot indicators.
- Made each pager image clickable for future navigation use.
- Accepts a list of drawable resource IDs to populate the pager dynamically.